### PR TITLE
Add install_plugin Capistrano::Puma

### DIFF
--- a/method1/Capfile
+++ b/method1/Capfile
@@ -22,6 +22,7 @@ require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/puma'
+install_plugin Capistrano::Puma
 # require 'capistrano/passenger'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined


### PR DESCRIPTION
This line is required for loading default puma tasks