### PR TITLE
Update NGINX file to prevent HTTP Origin Header issue with requests that requires token on Rails

### DIFF
--- a/method1/nginx
+++ b/method1/nginx
@@ -20,6 +20,11 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Connection '';
     proxy_pass http://app;
+    
+    # In case you add a redirect to HTTPS - Prevents HTTP Origin header (https://yourhost.com) didn't match request.base_url (http://yourhost.com)
+    proxy_set_header  X-Forwarded-Ssl on; # Optional
+    proxy_set_header  X-Forwarded-Port $server_port;
+    proxy_set_header  X-Forwarded-Host $host;
   }
 
   location ~ ^/(assets|fonts|system)/|favicon.ico|robots.txt {


### PR DESCRIPTION
Just added a configuration to avoid issues with:
`HTTP Origin header (https://yourhost.com) didn't match request.base_url (http://yourhost.com)`

It happens while making request that requires token and validates origin URL when you're redirectin from `HTTP` to `HTTPS`.

Just added these 3 lines on NGINX configuration file:
```
    proxy_set_header  X-Forwarded-Ssl on; # Optional
    proxy_set_header  X-Forwarded-Port $server_port;
    proxy_set_header  X-Forwarded-Host $host;
```